### PR TITLE
Live component url prop

### DIFF
--- a/src/LiveComponent/assets/dist/Component/plugins/QueryStringPluging.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/QueryStringPluging.d.ts
@@ -1,0 +1,9 @@
+import Component from '../index';
+import { PluginInterface } from './PluginInterface';
+export default class implements PluginInterface {
+    private element;
+    private mapping;
+    attachToComponent(component: Component): void;
+    private registerBindings;
+    private updateUrl;
+}

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2765,9 +2765,7 @@ class QueryStringPluging {
             return;
         }
         const mapping = JSON.parse(rawQueryMapping);
-        const defaults = { keep: false };
-        Object.entries(mapping).forEach(([key, value]) => {
-            const config = Object.assign(Object.assign({}, defaults), { name: value });
+        Object.entries(mapping).forEach(([key, config]) => {
             this.mapping.set(key, config);
         });
     }
@@ -2775,9 +2773,7 @@ class QueryStringPluging {
         this.mapping.forEach((mapping, propName) => {
             const value = component.valueStore.get(propName);
             if (value === '' || value === null || value === undefined) {
-                mapping.keep
-                    ? setQueryParam(mapping.name, '')
-                    : removeQueryParam(mapping.name);
+                removeQueryParam(mapping.name);
             }
             else {
                 setQueryParam(mapping.name, value);

--- a/src/LiveComponent/assets/dist/url_utils.d.ts
+++ b/src/LiveComponent/assets/dist/url_utils.d.ts
@@ -1,0 +1,2 @@
+export declare function setQueryParam(param: string, value: any): void;
+export declare function removeQueryParam(param: string): void;

--- a/src/LiveComponent/assets/src/Component/plugins/QueryStringPluging.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/QueryStringPluging.ts
@@ -1,0 +1,55 @@
+import Component from '../index';
+import { PluginInterface } from './PluginInterface';
+import {
+    setQueryParam, removeQueryParam,
+} from '../../url_utils';
+
+type QueryMapping  = {
+    name: string,
+    keep: boolean,
+}
+
+export default class implements PluginInterface {
+    private element: Element;
+    private mapping: Map<string,QueryMapping> = new Map;
+
+    attachToComponent(component: Component): void {
+        this.element = component.element;
+        this.registerBindings();
+
+        component.on('connect', (component: Component) => {
+            this.updateUrl(component);
+        });
+
+        component.on('render:finished', (component: Component)=> {
+            this.updateUrl(component);
+        });
+    }
+
+    private registerBindings(): void {
+        const rawQueryMapping = (this.element as HTMLElement).dataset.liveQueryMapping;
+        if (rawQueryMapping === undefined) {
+            return;
+        }
+        const mapping = JSON.parse(rawQueryMapping) as Object;
+        const defaults = {keep: false} as QueryMapping;
+        Object.entries(mapping).forEach(([key, value]) => {
+            const config = {...defaults, name: value} as QueryMapping;
+            this.mapping.set(key, config);
+        })
+    }
+
+    private updateUrl(component: Component){
+        this.mapping.forEach((mapping, propName) => {
+            const value = component.valueStore.get(propName);
+            if (value === '' || value === null || value === undefined) {
+                mapping.keep
+                    ? setQueryParam(mapping.name, '')
+                    : removeQueryParam(mapping.name);
+            } else {
+                setQueryParam(mapping.name, value);
+            }
+
+        });
+    }
+}

--- a/src/LiveComponent/assets/src/Component/plugins/QueryStringPluging.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/QueryStringPluging.ts
@@ -6,7 +6,6 @@ import {
 
 type QueryMapping  = {
     name: string,
-    keep: boolean,
 }
 
 export default class implements PluginInterface {
@@ -32,9 +31,7 @@ export default class implements PluginInterface {
             return;
         }
         const mapping = JSON.parse(rawQueryMapping) as Object;
-        const defaults = {keep: false} as QueryMapping;
-        Object.entries(mapping).forEach(([key, value]) => {
-            const config = {...defaults, name: value} as QueryMapping;
+        Object.entries(mapping).forEach(([key, config]) => {
             this.mapping.set(key, config);
         })
     }
@@ -43,9 +40,7 @@ export default class implements PluginInterface {
         this.mapping.forEach((mapping, propName) => {
             const value = component.valueStore.get(propName);
             if (value === '' || value === null || value === undefined) {
-                mapping.keep
-                    ? setQueryParam(mapping.name, '')
-                    : removeQueryParam(mapping.name);
+                removeQueryParam(mapping.name);
             } else {
                 setQueryParam(mapping.name, value);
             }

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -18,6 +18,7 @@ import SetValueOntoModelFieldsPlugin from './Component/plugins/SetValueOntoModel
 import { PluginInterface } from './Component/plugins/PluginInterface';
 import getModelBinding from './Directive/get_model_binding';
 import ComponentRegistry from './ComponentRegistry';
+import QueryStringPluging from './Component/plugins/QueryStringPluging';
 
 export { Component };
 export const getComponent = (element: HTMLElement): Promise<Component> =>
@@ -102,6 +103,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             new PageUnloadingPlugin(),
             new PollingPlugin(),
             new SetValueOntoModelFieldsPlugin(),
+            new QueryStringPluging()
         ];
         plugins.forEach((plugin) => {
             this.component.addPlugin(plugin);

--- a/src/LiveComponent/assets/src/url_utils.ts
+++ b/src/LiveComponent/assets/src/url_utils.ts
@@ -1,0 +1,59 @@
+class AdvancedURLSearchParams extends URLSearchParams
+{
+    set(name: string, value: any) {
+        if (typeof value !== 'object') {
+            super.set(name, value);
+        }
+        else {
+            this.delete(name);
+            if (Array.isArray(value)) {
+                value.forEach((v) => {
+                    this.append(`${name}[]`, v);
+                })
+            } else {
+                Object.entries(value).forEach(([index, v]) => {
+                    this.append(`${name}[${index}]`, v as string);
+                })
+            }
+        }
+    }
+
+    delete(name: string) {
+        super.delete(name);
+        const pattern = new RegExp(`^${name}(\\[.*\\])?$`);
+        for (let key of this.keys()) {
+            if (key.match(pattern)) {
+                this.delete(key);
+            }
+        }
+    }
+}
+
+export function setQueryParam(param: string, value: any) {
+    let queryParams = new AdvancedURLSearchParams(window.location.search);
+
+    queryParams.set(param, value);
+
+    let url = urlFromQueryParams(queryParams)
+
+    history.replaceState(history.state, '', url)
+}
+
+export function removeQueryParam(param: string) {
+    let queryParams = new AdvancedURLSearchParams(window.location.search);
+
+    queryParams.delete(param);
+
+    let url = urlFromQueryParams(queryParams)
+
+    history.replaceState(history.state, '', url)
+}
+
+function urlFromQueryParams(queryParams: URLSearchParams) {
+    let queryString = '';
+    if (Array.from(queryParams.entries()).length > 0) {
+        queryString += '?' + queryParams.toString()
+    }
+
+    return window.location.origin + window.location.pathname + queryString + window.location.hash
+}

--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -60,7 +60,7 @@ final class LiveProp
      */
     private null|string|array $onUpdated;
 
-    private LiveUrl|null $url;
+    private LiveUrl|bool $url;
 
     /**
      * @param bool|array  $writable                  If true, this property can be changed by the frontend.
@@ -100,14 +100,7 @@ final class LiveProp
         $this->acceptUpdatesFromParent = $updateFromParent;
         $this->onUpdated = $onUpdated;
 
-        if ($url) {
-            if (true === $url) {
-                $url = new LiveUrl();
-            }
-            $this->url = $url;
-        } else {
-            $this->url = null;
-        }
+        $this->url = (true === $url) ? new LiveUrl() : $url;
 
         if ($this->useSerializerForHydration && ($this->hydrateWith || $this->dehydrateWith)) {
             throw new \InvalidArgumentException('Cannot use useSerializerForHydration with hydrateWith or dehydrateWith.');
@@ -203,7 +196,7 @@ final class LiveProp
         return $this->onUpdated;
     }
 
-    public function url(): ?LiveUrl
+    public function url(): LiveUrl|bool
     {
         return $this->url;
     }

--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\UX\LiveComponent\Attribute;
 
+use Symfony\UX\LiveComponent\Util\LiveUrl;
+
 /**
  * @experimental
  */
@@ -58,6 +60,8 @@ final class LiveProp
      */
     private null|string|array $onUpdated;
 
+    private LiveUrl|null $url;
+
     /**
      * @param bool|array  $writable                  If true, this property can be changed by the frontend.
      *                                               Or set to an array of paths within this object/array
@@ -84,6 +88,7 @@ final class LiveProp
         string $format = null,
         bool $updateFromParent = false,
         string|array $onUpdated = null,
+        bool|LiveUrl $url = false,
     ) {
         $this->writable = $writable;
         $this->hydrateWith = $hydrateWith;
@@ -94,6 +99,15 @@ final class LiveProp
         $this->format = $format;
         $this->acceptUpdatesFromParent = $updateFromParent;
         $this->onUpdated = $onUpdated;
+
+        if ($url) {
+            if (true === $url) {
+                $url = new LiveUrl();
+            }
+            $this->url = $url;
+        } else {
+            $this->url = null;
+        }
 
         if ($this->useSerializerForHydration && ($this->hydrateWith || $this->dehydrateWith)) {
             throw new \InvalidArgumentException('Cannot use useSerializerForHydration with hydrateWith or dehydrateWith.');
@@ -187,5 +201,10 @@ final class LiveProp
     public function onUpdated(): null|string|array
     {
         return $this->onUpdated;
+    }
+
+    public function url(): ?LiveUrl
+    {
+        return $this->url;
     }
 }

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -45,6 +45,7 @@ use Symfony\UX\LiveComponent\Util\ChildComponentPartialRenderer;
 use Symfony\UX\LiveComponent\Util\FingerprintCalculator;
 use Symfony\UX\LiveComponent\Util\LiveComponentStack;
 use Symfony\UX\LiveComponent\Util\LiveControllerAttributesCreator;
+use Symfony\UX\LiveComponent\Util\QueryStringPropsExtractor;
 use Symfony\UX\LiveComponent\Util\TwigAttributeHelperFactory;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentRenderer;
@@ -217,10 +218,13 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             ->addTag('container.service_subscriber', ['key' => LiveControllerAttributesCreator::class, 'id' => 'ux.live_component.live_controller_attributes_creator'])
         ;
 
+        $container->register('ux.live_component.query_string_props_extractor', QueryStringPropsExtractor::class);
+
         $container->register('ux.live_component.query_string_initializer_subscriber', QueryStringInitializeSubscriber::class)
             ->setArguments([
                 new Reference('request_stack'),
                 new Reference('ux.live_component.metadata_factory'),
+                new Reference('ux.live_component.query_string_props_extractor'),
             ])
             ->addTag('kernel.event_subscriber');
 

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -28,6 +28,7 @@ use Symfony\UX\LiveComponent\EventListener\DataModelPropsSubscriber;
 use Symfony\UX\LiveComponent\EventListener\DeferLiveComponentSubscriber;
 use Symfony\UX\LiveComponent\EventListener\InterceptChildComponentRenderSubscriber;
 use Symfony\UX\LiveComponent\EventListener\LiveComponentSubscriber;
+use Symfony\UX\LiveComponent\EventListener\QueryStringInitializeSubscriber;
 use Symfony\UX\LiveComponent\EventListener\ResetDeterministicIdSubscriber;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
 use Symfony\UX\LiveComponent\Hydration\HydrationExtensionInterface;
@@ -215,6 +216,13 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             ->addTag('kernel.event_subscriber')
             ->addTag('container.service_subscriber', ['key' => LiveControllerAttributesCreator::class, 'id' => 'ux.live_component.live_controller_attributes_creator'])
         ;
+
+        $container->register('ux.live_component.query_string_initializer_subscriber', QueryStringInitializeSubscriber::class)
+            ->setArguments([
+                new Reference('request_stack'),
+                new Reference('ux.live_component.metadata_factory'),
+            ])
+            ->addTag('kernel.event_subscriber');
 
         $container->register('ux.live_component.defer_live_component_subscriber', DeferLiveComponentSubscriber::class)
             ->setArguments([

--- a/src/LiveComponent/src/EventListener/QueryStringInitializeSubscriber.php
+++ b/src/LiveComponent/src/EventListener/QueryStringInitializeSubscriber.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadata;
+use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadataFactory;
+use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreMountEvent;
+
+class QueryStringInitializeSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var array<class-string,LiveComponentMetadata>
+     */
+    private array $registered = [];
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly LiveComponentMetadataFactory $metadataFactory,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreCreateForRenderEvent::class => 'onPreCreateForRenderEvent',
+            PreMountEvent::class => 'onPreMount',
+        ];
+    }
+
+    public function onPreMount(PreMountEvent $event): void
+    {
+        $component = $event->getComponent();
+        if (!($metadata = $this->registered[$component::class])) {
+            return;
+        }
+
+        $data = $event->getData();
+        $request = $this->requestStack->getCurrentRequest();
+        foreach ($metadata->getAllLivePropsMetadata() as $livePropMetadata) {
+            if ([] !== ($queryStringBinding = $livePropMetadata->getQueryStringMapping())) {
+                foreach ($queryStringBinding['parameters'] as $parameterName => $binding) {
+                    if ($request->query->has($parameterName)) {
+                        $value = $request->query->get($parameterName);
+                        settype($value, $binding['type']);
+                        $data[$binding['property'] ?? $parameterName] = $value;
+                    }
+                }
+            }
+        }
+
+        $event->setData($data);
+    }
+
+    public function onPreCreateForRenderEvent(PreCreateForRenderEvent $event): void
+    {
+        $componentName = $event->getName();
+        $metadata = $this->metadataFactory->getMetadata($componentName);
+        if ($metadata->hasQueryStringBindings()) {
+            $this->registered[$metadata->getComponentMetadata()->getClass()] = $metadata;
+        }
+    }
+}

--- a/src/LiveComponent/src/EventListener/QueryStringInitializeSubscriber.php
+++ b/src/LiveComponent/src/EventListener/QueryStringInitializeSubscriber.php
@@ -54,7 +54,7 @@ class QueryStringInitializeSubscriber implements EventSubscriberInterface
                     if ($request->query->has($parameterName)) {
                         $value = $request->query->get($parameterName);
                         settype($value, $binding['type']);
-                        $data[$binding['property'] ?? $parameterName] = $value;
+                        $data[$binding['property']] = $value;
                     }
                 }
             }

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
@@ -61,4 +61,15 @@ class LiveComponentMetadata
 
         return array_intersect_key($inputProps, array_flip($propNames));
     }
+
+    public function hasQueryStringBindings(): bool
+    {
+        foreach ($this->getAllLivePropsMetadata() as $livePropMetadata) {
+            if ([] !== $livePropMetadata->getQueryStringMapping()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -170,6 +170,7 @@ class LiveComponentMetadataFactory
                 throw new \LogicException('Alias must be a string when using URL binding on a scalar property');
             }
             $parameters[$alias ?? $propertyName] = [
+                'property' => $propertyName,
                 'type' => $infoType ?? 'string',
             ];
         }

--- a/src/LiveComponent/src/Metadata/LivePropMetadata.php
+++ b/src/LiveComponent/src/Metadata/LivePropMetadata.php
@@ -30,6 +30,7 @@ final class LivePropMetadata
         private bool $isBuiltIn,
         private bool $allowsNull,
         private ?Type $collectionValueType,
+        private array $queryStringMapping = [],
     ) {
     }
 
@@ -51,6 +52,11 @@ final class LivePropMetadata
     public function allowsNull(): bool
     {
         return $this->allowsNull;
+    }
+
+    public function getQueryStringMapping(): ?array
+    {
+        return $this->queryStringMapping;
     }
 
     public function calculateFieldName(object $component, string $fallback): string

--- a/src/LiveComponent/src/Metadata/LivePropMetadata.php
+++ b/src/LiveComponent/src/Metadata/LivePropMetadata.php
@@ -54,7 +54,7 @@ final class LivePropMetadata
         return $this->allowsNull;
     }
 
-    public function getQueryStringMapping(): ?array
+    public function getQueryStringMapping(): array
     {
         return $this->queryStringMapping;
     }

--- a/src/LiveComponent/src/Util/LiveAttributesCollection.php
+++ b/src/LiveComponent/src/Util/LiveAttributesCollection.php
@@ -97,6 +97,11 @@ final class LiveAttributesCollection
         $this->attributes['data-live-browser-dispatch'] = $browserEventsToDispatch;
     }
 
+    public function setQueryUrlMapping(array $queryUrlMapping): void
+    {
+        $this->attributes['data-live-query-mapping'] = $queryUrlMapping;
+    }
+
     private function escapeAttribute(string $value): string
     {
         return twig_escape_filter($this->twig, $value, 'html_attr');

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -127,7 +127,12 @@ class LiveControllerAttributesCreator
             foreach ($liveMetadata->getAllLivePropsMetadata() as $livePropMetadata) {
                 if ($mapping = $livePropMetadata->getQueryStringMapping()) {
                     foreach ($mapping['parameters'] as $parameter => $config) {
-                        $queryMapping[$config['property']] = $parameter;
+                        if (isset($mapping[$config['property']])) {
+                            throw new \LogicException('Duplicate property');
+                        }
+                        $queryMapping[$config['property']] = [
+                            'name' => $parameter,
+                        ];
                     }
                 }
             }

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -121,6 +121,19 @@ class LiveControllerAttributesCreator
             );
         }
 
+        $liveMetadata = $this->metadataFactory->getMetadata($mounted->getName());
+        if ($liveMetadata->hasQueryStringBindings()) {
+            $queryMapping = [];
+            foreach ($liveMetadata->getAllLivePropsMetadata() as $livePropMetadata) {
+                if ($mapping = $livePropMetadata->getQueryStringMapping()) {
+                    foreach ($mapping['parameters'] as $parameter => $config) {
+                        $queryMapping[$config['property']] = $parameter;
+                    }
+                }
+            }
+            $attributesCollection->setQueryUrlMapping($queryMapping);
+        }
+
         return $attributesCollection;
     }
 

--- a/src/LiveComponent/src/Util/LiveUrl.php
+++ b/src/LiveComponent/src/Util/LiveUrl.php
@@ -13,32 +13,5 @@ namespace Symfony\UX\LiveComponent\Util;
 
 final class LiveUrl
 {
-    public function __construct(
-        private readonly string|array|null $alias = null,
-        private readonly array|null $mapping = null,
-        private readonly bool $keep = false,
-        private readonly bool $history = false,
-    ) {
-    }
-
-
-    public function getAlias(): string|array|null
-    {
-        return $this->alias;
-    }
-
-    public function keep(): bool
-    {
-        return $this->keep;
-    }
-
-    public function history(): bool
-    {
-        return $this->history;
-    }
-
-    public function getMapping(): ?array
-    {
-        return $this->mapping;
-    }
+    public function __construct() {}
 }

--- a/src/LiveComponent/src/Util/LiveUrl.php
+++ b/src/LiveComponent/src/Util/LiveUrl.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Util;
+
+final class LiveUrl
+{
+    public function __construct(
+        private readonly string|array|null $alias = null,
+        private readonly array|null $mapping = null,
+        private readonly bool $keep = false,
+        private readonly bool $history = false,
+    ) {
+    }
+
+
+    public function getAlias(): string|array|null
+    {
+        return $this->alias;
+    }
+
+    public function keep(): bool
+    {
+        return $this->keep;
+    }
+
+    public function history(): bool
+    {
+        return $this->history;
+    }
+
+    public function getMapping(): ?array
+    {
+        return $this->mapping;
+    }
+}

--- a/src/LiveComponent/src/Util/QueryStringPropsExtractor.php
+++ b/src/LiveComponent/src/Util/QueryStringPropsExtractor.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Util;
+
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadata;
+
+class QueryStringPropsExtractor
+{
+    public function extract(string $queryString, LiveComponentMetadata $metadata): array
+    {
+        if (empty($queryString)) {
+            return [];
+        }
+
+        $query = HeaderUtils::parseQuery($queryString);
+
+        $data = [];
+
+        foreach ($metadata->getAllLivePropsMetadata() as $livePropMetadata) {
+            $queryStringBinding = $livePropMetadata->getQueryStringMapping();
+            foreach ($queryStringBinding['parameters'] ?? [] as $parameterName => $paramConfig) {
+                if (isset($query[$parameterName])) {
+                    $data[$paramConfig['property']] = $this->normalizeValue($query[$parameterName], $paramConfig);
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    private function normalizeValue(mixed $value, array $config): mixed
+    {
+        if (\in_array($config['type'], [Type::BUILTIN_TYPE_BOOL, Type::BUILTIN_TYPE_FLOAT, Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_STRING, Type::BUILTIN_TYPE_ARRAY])) {
+            settype($value, $config['type']);
+
+            return $value;
+        }
+
+        throw new \LogicException(sprintf('Prop of type "%s" cannot be extracted from query string.', $config['type']));
+    }
+}


### PR DESCRIPTION
Bind LiveProps to URL query parameters.

Main goals:

- [x] Configure `LiveProp` to have query parameter binding
- [x] Init props with initial query string parameters
- [x] Update URL along with bound props

Nice to have: 
- [ ] Keep param in URL even if empty or missing
- [x] Alias for bound query parameters
- [ ] History mode (replace/push)
- [ ] Query string method in `LiveComponent` instead of attribute configuration

